### PR TITLE
S3DF Build Fix and Warning Fixes

### DIFF
--- a/src/McsRead.cpp
+++ b/src/McsRead.cpp
@@ -111,7 +111,7 @@ uint32_t McsRead::addrSize ( ) {
 
 // Get next memory data and address index
 int32_t McsRead::read (McsReadData *mem) {
-   int32_t status;
+   int32_t status = 0;
 
    //check if we need to read the next line
    if(promPntr==16) {

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,16 @@ CCACHE_DISABLE=1
 LDFLAGS += -Wl,-Bstatic -static-libgcc
 #LDFLAGS += -Wl,-Bstatic
 #
-CPSW_DIR=/afs/slac/g/lcls/package/cpsw/framework/R4.4.1/src
+
+ifeq ($(PACKAGE_TOP),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+	PACKAGE_TOP=$(EPICS_PACKAGE_TOP)
+else
+	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided in the environment or on the command line)
+endif
+endif
+
+CPSW_DIR=$(PACKAGE_TOP)/cpsw/framework/R4.4.1/src
 
 # may override CPSW_DIR / DEVICELIB_DIR from release.mak
 # must set SRCDIR (is redefined by recursive make)

--- a/src/tpr.cc
+++ b/src/tpr.cc
@@ -11,6 +11,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 using namespace Tpr;
 
@@ -281,7 +282,7 @@ void RingB::dumpFrames() const
     v = (v>>16) | (uint64_t(data[j++])<<48);    \
     v = (v>>16) | (uint64_t(data[j++])<<48);    \
     v = (v>>16) | (uint64_t(data[j++])<<48);    \
-    printf("%16lx ",v);                         \
+    printf("%16" PRIx64 " ",v);                 \
   }
   printf("%8.8s %16.16s %16.16s %8.8s %8.8s %16.16s %16.16s %16.16s %16.16s\n",
          "Version","PulseID","TimeStamp","Markers","BeamReq",

--- a/src/tprTriggerYaml.cc
+++ b/src/tprTriggerYaml.cc
@@ -158,7 +158,7 @@ void TprTriggerYaml::InitLCLS1Mode(void)
     uint32_t zero(0), dontcare(0x20000);
     CPSW_TRY_CATCH(_clkSel->setVal(&zero));         /* Select LCLS1 mode clock */
     
-    for(uint32_t i = 0; i < num_channels; i++) {
+    for(uint32_t i = 0; i < (uint32_t)num_channels; i++) {
         CPSW_TRY_CATCH(_chnDestSelect[i]->setVal(&dontcare));  /* destination, don't care */
         CPSW_TRY_CATCH(_trgSourceMask[i]->setVal(&i));         /* one to one mapping between channel and trigger */
     }
@@ -375,7 +375,7 @@ void TprTriggerYaml::SetComplTrg(int trigger, uint32_t comp)
             break;
     }
 
-    if(_debug_) printf("TprTriggerYaml (%d): compl_trigger(trg %x, comm %8.8lx)\n", this, trigger, (unsigned long) comp);
+    if(_debug_) printf("TprTriggerYaml (%p): compl_trigger(trg %x, comm %8.8lx)\n", this, trigger, (unsigned long) comp);
 }
 
 void TprTriggerYaml::SetDelayTap(int trigger, uint32_t tap)
@@ -388,7 +388,7 @@ void TprTriggerYaml::SetDelayTap(int trigger, uint32_t tap)
 
 void TprTriggerYaml::report(void)
 {
-    char *str_bus_type;
+    const char *str_bus_type = NULL;
     switch(bus_type) {
         case _atca:
             str_bus_type = "ATCA TPR";

--- a/src/tprtest.cc
+++ b/src/tprtest.cc
@@ -403,7 +403,7 @@ void frame_capture(TprReg& reg, char tprid, TimingMode tmode )
   } while(1);
 
 
-  uint64_t active, avgdn, update, init, minor, major;
+  uint64_t active, avgdn, update = 0, init, minor, major;
   nframes = 0;
   do {
     while(bsarp < q.bsawp && nframes<10) {


### PR DESCRIPTION
* CPSW path is now relative to `PACKAGE_TOP`. If `PACKAGE_TOP` is not already defined by the environment, it gets defaulted to `EPICS_PACKAGE_TOP` (if that exists, for compatibility with the new S3DF env)
* Fixed some warnings